### PR TITLE
[WORKAROUND] AnyKernel3: dynamically use OG AK when needed

### DIFF
--- a/anykernel.sh
+++ b/anykernel.sh
@@ -32,6 +32,15 @@ customdd="bs=1048576"
 ## AnyKernel install
 split_boot;
 
+# Add skip_override parameter to cmdline so user doesn't have to reflash Magisk
+if [ -d $ramdisk/.backup ]; then
+  ui_print " "; 
+  ui_print "Magisk detected! Patching cmdline so reflashing Magisk is not necessary...";
+  patch_cmdline "skip_override" "skip_override";
+else
+  patch_cmdline "skip_override" "";
+fi;
+
 if mountpoint -q /data; then
   # Optimize F2FS extension list (@arter97)
   for list_path in $(find /sys/fs/f2fs* -name extension_list); do
@@ -68,27 +77,6 @@ if mountpoint -q /data; then
     done
   done
 fi
-
-decomp_image=$home/Image
-comp_image=$decomp_image.gz-dtb
-
-# Hex-patch the kernel if Magisk is installed ('skip_initramfs' -> 'want_initramfs')
-# This negates the need to reflash Magisk afterwards
-if [ -f $comp_image ]; then
-  comp_rd=$split_img/ramdisk.cpio
-  decomp_rd=$home/_ramdisk.cpio
-  $bin/magiskboot decompress $comp_rd $decomp_rd || cp $comp_rd $decomp_rd
-
-  if $bin/magiskboot cpio $decomp_rd "exists .backup"; then
-    ui_print "  • Preserving Magisk";
-    $bin/magiskboot decompress $comp_image $decomp_image;
-    $bin/magiskboot hexpatch $decomp_image 736B69705F696E697472616D667300 77616E745F696E697472616D667300;
-    $bin/magiskboot compress=gzip $decomp_image $comp_image;
-  else
-  	ui_print "  • Magisk not found / not installed"
-  fi;
-fi;
-
 
 # end ramdisk changes
 

--- a/tools/ak3-core.sh
+++ b/tools/ak3-core.sh
@@ -158,7 +158,7 @@ unpack_ramdisk() {
   else
     # ramdisk.cpio is not present.
     magisk_present=false
-    abort "Magisk was not detected. Proceeding in OG AK mode...";
+    ui_print "Magisk was not detected. Proceeding in OG AK mode...";
   fi;
   if [ "$comp" ]; then
     mv -f ramdisk.cpio ramdisk.cpio.$comp;

--- a/tools/ak3-core.sh
+++ b/tools/ak3-core.sh
@@ -152,9 +152,13 @@ unpack_ramdisk() {
   fi;
 
   if [ -f ramdisk.cpio ]; then
+    # ramdisk.cpio is present. OG AK mode is not required.
+    magisk_present=true
     comp=$($bin/magiskboot decompress ramdisk.cpio 2>&1 | grep -v 'raw' | sed -n 's;.*\[\(.*\)\];\1;p');
   else
-    abort "No ramdisk found to unpack. Aborting...";
+    # ramdisk.cpio is not present.
+    magisk_present=false
+    abort "Magisk was not detected. Proceeding in OG AK mode...";
   fi;
   if [ "$comp" ]; then
     mv -f ramdisk.cpio ramdisk.cpio.$comp;


### PR DESCRIPTION
Since the hex patch was causing the kernel to not boot, this workaround will use the same old skip_override method to preserve Magisk. I'm leaving this pull request here for future purposes.