### PR TITLE
[WORKAROUND] AnyKernel3: check for magisk correctly

### DIFF
--- a/anykernel.sh
+++ b/anykernel.sh
@@ -30,6 +30,8 @@ customdd="bs=1048576"
 # import patching functions/variables - see for reference
 . tools/ak3-core.sh;
 
+magisk_check()
+
 ## AnyKernel install
 if [ "$magisk_present" = true ]; then
   # AnyKernel file attributes

--- a/tools/ak3-core.sh
+++ b/tools/ak3-core.sh
@@ -152,9 +152,11 @@ magisk_check() {
   if [ -f ramdisk.cpio ]; then
     # ramdisk.cpio is present. OG AK mode is not required.
     magisk_present=true
+    ramdisk_compression=auto
   else
     # ramdisk.cpio is not present. Set flag to false.
     magisk_present=false
+    ramdisk_compression=none
   fi;
 }
 

--- a/tools/ak3-core.sh
+++ b/tools/ak3-core.sh
@@ -138,6 +138,26 @@ split_boot() {
   cd $home;
 }
 
+# magisk_check (check for magisk)
+magisk_check() {
+  cd $split_img;
+  if [ -f ramdisk.cpio.gz ]; then
+    if [ -f "$bin/mkmtkhdr" ]; then
+      mv -f ramdisk.cpio.gz ramdisk.cpio.gz-mtk;
+      dd bs=512 skip=1 conv=notrunc if=ramdisk.cpio.gz-mtk of=ramdisk.cpio.gz;
+    fi;
+    mv -f ramdisk.cpio.gz ramdisk.cpio;
+  fi;
+
+  if [ -f ramdisk.cpio ]; then
+    # ramdisk.cpio is present. OG AK mode is not required.
+    magisk_present=true
+  else
+    # ramdisk.cpio is not present. Set flag to false.
+    magisk_present=false
+  fi;
+}
+
 # unpack_ramdisk (extract ramdisk only)
 unpack_ramdisk() {
   local comp;
@@ -152,12 +172,8 @@ unpack_ramdisk() {
   fi;
 
   if [ -f ramdisk.cpio ]; then
-    # ramdisk.cpio is present. OG AK mode is not required.
-    magisk_present=true
     comp=$($bin/magiskboot decompress ramdisk.cpio 2>&1 | grep -v 'raw' | sed -n 's;.*\[\(.*\)\];\1;p');
   else
-    # ramdisk.cpio is not present.
-    magisk_present=false
     ui_print "Magisk was not detected. Proceeding in OG AK mode...";
   fi;
   if [ "$comp" ]; then


### PR DESCRIPTION
In the previous commit, the Magisk presence flag would still be null because the function to unpack ramdisk is not called by merely executing ak3-core.sh